### PR TITLE
Correccion punto 4 de la entrega 1. 

### DIFF
--- a/ResstApp/src/main/java/com/tacs/ResstApp/controllers/GitRepositoryController.java
+++ b/ResstApp/src/main/java/com/tacs/ResstApp/controllers/GitRepositoryController.java
@@ -1,10 +1,9 @@
 package com.tacs.ResstApp.controllers;
 
-import com.tacs.ResstApp.services.exceptions.ServiceException;
-import com.tacs.ResstApp.services.impl.RepositoryService;
-import com.tacs.ResstApp.services.impl.UserService;
+import java.time.LocalDate;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +11,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import com.tacs.ResstApp.services.exceptions.ServiceException;
+import com.tacs.ResstApp.services.impl.RepositoryService;
+import com.tacs.ResstApp.services.impl.UserService;
 
 @RestController
 public class GitRepositoryController {
@@ -38,9 +39,9 @@ public class GitRepositoryController {
     }
 
     @GetMapping("/repositories")
-    public ResponseEntity<Object> getRepositoryByDate(@RequestParam("since") LocalDateTime since, @RequestParam("to") LocalDateTime to, @RequestParam("start") int start, @RequestParam("limit") int limit){
+    public ResponseEntity<Object> getRepositoryByDate(@RequestParam("since") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate since, @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to, @RequestParam(name = "start", required = false) Integer start, @RequestParam(name = "limit", required = false) Integer limit){
         try {
-            return ResponseEntity.ok(repositoryMockService.getRepositoriesBetween(since, to));
+            return ResponseEntity.ok(repositoryMockService.getRepositoriesBetween(since.atStartOfDay(), to.atStartOfDay()));
         }
         catch(ServiceException ex){
             return ResponseEntity.badRequest().body(ex.getMessage());

--- a/ResstApp/src/test/java/com/tacs/ResstApp/GitRepositoryControllerTest.java
+++ b/ResstApp/src/test/java/com/tacs/ResstApp/GitRepositoryControllerTest.java
@@ -1,5 +1,6 @@
 package com.tacs.ResstApp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,8 +65,8 @@ class GitRepositoryControllerTest {
 		Repository repo1 = new Repository(1L, "repo 1");
 		Repository repo2 = new Repository(2L, "repo 2");
 		Repository repo3 = new Repository(3L, "repo 3");
-		LocalDateTime since = LocalDateTime.now();
-		LocalDateTime to = LocalDateTime.now();
+		LocalDate since = LocalDate.now();
+		LocalDate to = LocalDate.now();
 		Mockito.when(repositoryMockService.getRepositoriesBetween(Mockito.any(LocalDateTime.class),
 				Mockito.any(LocalDateTime.class))).thenReturn(new ArrayList<>(Arrays.asList(repo1, repo2, repo3)));
 		ResponseEntity<Object> response = gitRepositoryController.getRepositoryByDate(since, to, 1, 1);
@@ -84,7 +85,7 @@ class GitRepositoryControllerTest {
 	public void getRepositoriesError() throws Exception {
 		Mockito.when(repositoryMockService.getRepositoriesBetween(Mockito.any(LocalDateTime.class),
 				Mockito.any(LocalDateTime.class))).thenThrow(ServiceException.class);
-		ResponseEntity<Object> response = gitRepositoryController.getRepositoryByDate(LocalDateTime.now(), LocalDateTime.now(), 1, 1);
+		ResponseEntity<Object> response = gitRepositoryController.getRepositoryByDate(LocalDate.now(), LocalDate.now(), 1, 1);
 		Assertions.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
 		List<Repository> returnedRepos = (List) response.getBody();
 		Assertions.assertNull(returnedRepos);


### PR DESCRIPTION
Cambie los parámetros de la búsqueda de repositorios para que sea con formato "yyyy-MM-dd".